### PR TITLE
Fix image and make it a bit more configurable

### DIFF
--- a/conf/druid/_common/common.runtime.properties
+++ b/conf/druid/_common/common.runtime.properties
@@ -24,7 +24,7 @@
 # This is not the full list of Druid extensions, but common ones that people often use. You may need to change this list
 # based on your particular setup.
 druid.extensions.directory=/opt/druid/extensions
-druid.extensions.loadList=["druid-kafka-eight", "druid-s3-extensions", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "mysql-metadata-storage", "druid-kafka-indexing-service", "druid-avro-extensions"]
+druid.extensions.loadList=["druid-kafka-eight", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "mysql-metadata-storage", "druid-kafka-indexing-service", "druid-avro-extensions"]
 
 # If you have a different version of Hadoop, place your Hadoop client jar files in your hadoop-dependencies directory
 # and uncomment the line below to point to your directory.

--- a/conf/druid/_common/common.runtime.properties
+++ b/conf/druid/_common/common.runtime.properties
@@ -24,7 +24,7 @@
 # This is not the full list of Druid extensions, but common ones that people often use. You may need to change this list
 # based on your particular setup.
 druid.extensions.directory=/opt/druid/extensions
-druid.extensions.loadList=["druid-kafka-eight", "druid-s3-extensions", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "mysql-metadata-storage", "druid-kafka-indexing-service", "druid-avro-extensions"]
+druid.extensions.loadList=["druid-kafka-eight", "druid-s3-extensions", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "XXX-metadata-storage", "druid-kafka-indexing-service", "druid-avro-extensions"]
 
 # If you have a different version of Hadoop, place your Hadoop client jar files in your hadoop-dependencies directory
 # and uncomment the line below to point to your directory.

--- a/conf/druid/_common/common.runtime.properties
+++ b/conf/druid/_common/common.runtime.properties
@@ -24,7 +24,7 @@
 # This is not the full list of Druid extensions, but common ones that people often use. You may need to change this list
 # based on your particular setup.
 druid.extensions.directory=/opt/druid/extensions
-druid.extensions.loadList=["druid-kafka-eight", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "mysql-metadata-storage", "druid-kafka-indexing-service", "druid-avro-extensions"]
+druid.extensions.loadList=["druid-kafka-eight", "druid-s3-extensions", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "mysql-metadata-storage", "druid-kafka-indexing-service", "druid-avro-extensions"]
 
 # If you have a different version of Hadoop, place your Hadoop client jar files in your hadoop-dependencies directory
 # and uncomment the line below to point to your directory.
@@ -71,36 +71,36 @@ druid.metadata.storage.connector.password=...
 #
 
 # For local disk (only viable in a cluster if this is a network mount):
-druid.storage.type=local
-druid.storage.storageDirectory=var/druid/segments
+#druid.storage.type=local
+#druid.storage.storageDirectory=var/druid/segments
 
 # For HDFS (make sure to include the HDFS extension and that your Hadoop config files in the cp):
 #druid.storage.type=hdfs
 #druid.storage.storageDirectory=/druid/segments
 
 # For S3:
-# druid.storage.type=s3
-# druid.storage.bucket=your-bucket
-# druid.storage.baseKey=druid/segments
-# druid.s3.accessKey=...
-# druid.s3.secretKey=...
+druid.storage.type=s3
+druid.storage.bucket=your-bucket
+druid.storage.baseKey=druid/segments
+druid.s3.accessKey=...
+druid.s3.secretKey=...
 
 #
 # Indexing service logs
 #
 
 # For local disk (only viable in a cluster if this is a network mount):
-druid.indexer.logs.type=file
-druid.indexer.logs.directory=var/druid/indexing-logs
+# druid.indexer.logs.type=file
+# druid.indexer.logs.directory=var/druid/indexing-logs
 
 # For HDFS (make sure to include the HDFS extension and that your Hadoop config files in the cp):
 #druid.indexer.logs.type=hdfs
 #druid.indexer.logs.directory=/druid/indexing-logs
 
 # For S3:
-# druid.indexer.logs.type=s3
-# druid.indexer.logs.s3Bucket=your-bucket
-# druid.indexer.logs.s3Prefix=druid/indexing-logs
+druid.indexer.logs.type=s3
+druid.indexer.logs.s3Bucket=your-bucket
+druid.indexer.logs.s3Prefix=druid/indexing-logs
 
 #
 # Service discovery

--- a/conf/druid/_common/jets3t.properties
+++ b/conf/druid/_common/jets3t.properties
@@ -1,0 +1,2 @@
+s3service.s3-endpoint=s3.ippen.cloud
+s3service.disable-dns-buckets=true

--- a/start-druid.sh
+++ b/start-druid.sh
@@ -30,6 +30,8 @@ if [ "$DRUID_LOGLEVEL" != "-" ]; then
     sed -ri 's/druid.emitter.logging.logLevel=.*/druid.emitter.logging.logLevel='${DRUID_LOGLEVEL}'/g' /opt/druid/conf/druid/_common/common.runtime.properties
 fi
 
+sed -ri 's/XXX/'${DB_TYPE}'/' /opt/druid/conf/druid/_common/common.runtime.properties
+
 if [ "$DRUID_USE_CONTAINER_IP" != "-" ]; then
     ipaddress=`ip a|grep "global eth0"|awk '{print $2}'|awk -F '\/' '{print $1}'`
     sed -ri 's/druid.host=.*/druid.host='${ipaddress}'/g' /opt/druid/conf/druid/$1/runtime.properties

--- a/start-druid.sh
+++ b/start-druid.sh
@@ -14,10 +14,13 @@ sed -ri 's#druid.metadata.storage.type.*#druid.metadata.storage.type='${DB_TYPE}
 sed -ri 's#druid.metadata.storage.connector.connectURI.*#druid.metadata.storage.connector.connectURI='${DB_CONNECT_URI}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
 sed -ri 's#druid.metadata.storage.connector.user.*#druid.metadata.storage.connector.user='${DB_USERNAME}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
 sed -ri 's#druid.metadata.storage.connector.password.*#druid.metadata.storage.connector.password='${DB_PASSWORD}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
-# sed -ri 's#druid.s3.accessKey.*#druid.s3.accessKey='${S3_ACCESS_KEY}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
-# sed -ri 's#druid.s3.secretKey.*#druid.s3.secretKey='${S3_SECRET_KEY}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
-# sed -ri 's#druid.storage.bucket.*#druid.storage.bucket='${S3_STORAGE_BUCKET}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
-# sed -ri 's#druid.indexer.logs.s3Bucket.*#druid.indexer.logs.s3Bucket='${S3_INDEXING_BUCKET}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
+
+sed -ri 's#druid.s3.accessKey.*#druid.s3.accessKey='${S3_ACCESS_KEY}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
+sed -ri 's#druid.s3.secretKey.*#druid.s3.secretKey='${S3_SECRET_KEY}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
+sed -ri 's#druid.storage.bucket.*#druid.storage.bucket='${S3_STORAGE_BUCKET}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
+sed -ri 's#druid.indexer.logs.s3Bucket.*#druid.indexer.logs.s3Bucket='${S3_INDEXING_BUCKET}'#g' /opt/druid/conf/druid/_common/common.runtime.properties
+
+sed -ri 's#s3service.s3-endpoint=.*#s3service.s3-endpoint='${S3_ENDPOINT}'#g' /opt/druid/conf/druid/_common/jets3t.properties
 
 if [ "$DRUID_HOSTNAME" != "-" ]; then
     sed -ri 's/druid.host=.*/druid.host='${DRUID_HOSTNAME}'/g' /opt/druid/conf/druid/$1/runtime.properties


### PR DESCRIPTION
The current version of the image is broken, because it is configured to use local storage but still contains `druid-s3-extensions` which insists of talking to s3.

The first commit fixes this, making it work locally as probably intended.

The second commit fully activates S3, as local storage will probably not be a viable option.

The third commit allows to swap mysql and postgresql by using the suitable extension. 

There is probably a more sophisticated way to configure things, but I tried to make the changes as minimal as possible.

It should still work fine with the current helm chart. (But I already prepared another pull request for the chart to use the new possibilities.)