### PR TITLE
Add support for Apache Druid incubating 0.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ MAINTAINER Maciej Brynski <maciek@brynski.pl>
 # ENV S3_INDEXING_BUCKET druid-indexing
 # ENV S3_ACCESS_KEY      xxxxxxxxxxxx
 # ENV S3_ACCESS_KEY      xxxxxxxxxxxx
-ENV DRUID_VERSION      0.12.3
+ENV DRUID_VERSION      0.16.0-incubating
 
 # Druid env variable
 ENV DRUID_XMX          '-'
@@ -31,9 +31,11 @@ RUN apk update \
     && apk add --no-cache bash curl \
     && mkdir /tmp/druid \
     && curl \
-    http://static.druid.io/artifacts/releases/druid-$DRUID_VERSION-bin.tar.gz | tar -xzf - -C /opt \
-    && ln -s /opt/druid-$DRUID_VERSION /opt/druid
-RUN curl http://static.druid.io/artifacts/releases/mysql-metadata-storage-$DRUID_VERSION.tar.gz | tar -xzf - -C /opt/druid/extensions
+    https://archive.apache.org/dist/incubator/druid/$DRUID_VERSION/apache-druid-$DRUID_VERSION-bin.tar.gz | tar -xzf - -C /opt \
+    && ln -s /opt/apache-druid-$DRUID_VERSION /opt/druid
+
+RUN curl http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.38/mysql-connector-java-5.1.38.jar \
+    -o /opt/druid/extensions/mysql-metadata-storage/mysql-connector-java-5.1.38.jar
 
 COPY conf /opt/druid/conf
 COPY start-druid.sh /start-druid.sh

--- a/conf/druid/_common/common.runtime.properties
+++ b/conf/druid/_common/common.runtime.properties
@@ -24,7 +24,7 @@
 # This is not the full list of Druid extensions, but common ones that people often use. You may need to change this list
 # based on your particular setup.
 druid.extensions.directory=/opt/druid/extensions
-druid.extensions.loadList=["druid-kafka-eight", "druid-s3-extensions", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "mysql-metadata-storage", "druid-kafka-indexing-service", "druid-avro-extensions"]
+druid.extensions.loadList=["druid-s3-extensions", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "mysql-metadata-storage", "druid-kafka-indexing-service", "druid-avro-extensions"]
 
 # If you have a different version of Hadoop, place your Hadoop client jar files in your hadoop-dependencies directory
 # and uncomment the line below to point to your directory.

--- a/conf/druid/broker/runtime.properties
+++ b/conf/druid/broker/runtime.properties
@@ -34,3 +34,5 @@ druid.broker.cache.useCache=true
 druid.broker.cache.populateCache=true
 druid.cache.type=local
 druid.cache.sizeInBytes=2000000000
+
+druid.sql.enable=true

--- a/conf/druid/coordinator/runtime.properties
+++ b/conf/druid/coordinator/runtime.properties
@@ -23,4 +23,3 @@ druid.plaintextPort=8081
 
 druid.coordinator.startDelay=PT30S
 druid.coordinator.period=PT30S
-druid.coordinator.merge.on=true

--- a/start-druid.sh
+++ b/start-druid.sh
@@ -41,4 +41,4 @@ fi
 #     sed -ri 's/druid.storage.storageDirectory=.*/druid.storage.storageDirectory='${DRUID_DEEPSTORAGE_LOCAL_DIR}'/g' /opt/druid/conf/druid/_common/common.runtime.properties
 # fi
 
-java ${JAVA_OPTS} -cp /opt/druid/conf/druid/_common:/opt/druid/conf/druid/$1:/opt/druid/lib/* io.druid.cli.Main server $@
+java ${JAVA_OPTS} -cp /opt/druid/conf/druid/_common:/opt/druid/conf/druid/$1:/opt/druid/lib/* org.apache.druid.cli.Main server $@


### PR DESCRIPTION
Druid moved under Apache incubator project, including package changes, etc.

Modification list :
- Modified base image to support new archive path
- MySQL jar now needed under different path
- Added support for router node with base configuration